### PR TITLE
✨ feat: surface build backend versions with -vv

### DIFF
--- a/docs/changelog/959.feature.rst
+++ b/docs/changelog/959.feature.rst
@@ -1,0 +1,2 @@
+At ``-vv`` verbosity, print the resolved version of each installed build dependency as ``name==version`` so the exact
+backend version is available for bug reports (:issue:`959`) - by :user:`gaborbernat`.

--- a/docs/explanation/how-it-works.rst
+++ b/docs/explanation/how-it-works.rst
@@ -230,6 +230,24 @@ This:
 
 Useful for tools that need package metadata without building the full package.
 
+***************************
+ Diagnostics and Verbosity
+***************************
+
+``pyproject.toml`` declares build dependencies as *specifiers* (``setuptools >= 40.8.0``), not exact versions. The
+installer resolves each specifier to a concrete version at build time, and on an isolated build that version lives only
+in the temporary environment, which build deletes once it finishes. So the most useful piece of information for a
+backend bug report, the exact backend version, is gone by the time you need it.
+
+Building with ``-vv`` records it. Once build has installed the dependencies, it reports the resolved version of each one
+as ``name==version``. build obtains these by reading the installed distribution metadata from the environment's
+``site-packages`` through ``importlib.metadata`` rather than by spawning a process inside the environment, so the report
+is cheap and works the same for the ``venv``/``virtualenv`` and ``uv`` backends. Because it reads installed metadata, it
+reflects what build used, including any transitive resolution the specifier allowed.
+
+This is an isolated-build concern. Under ``--no-isolation`` build installs nothing - it builds against the interpreter
+that is already running it - so the versions are whatever that interpreter has, discoverable with your installer.
+
 ****************
  Error Handling
 ****************

--- a/docs/how-to/troubleshooting.rst
+++ b/docs/how-to/troubleshooting.rst
@@ -27,6 +27,28 @@ Build will read your ``pyproject.toml`` and install all required dependencies.
     $ pip install setuptools your-build-backend
     $ python -m build --no-isolation
 
+*******************************************
+ Find the backend version for a bug report
+*******************************************
+
+**Symptom**: A backend's issue tracker asks for the exact version of the backend you used, but the default output only
+shows the requirement specifiers (``setuptools >= 40.8.0``), not the version that was installed. On an isolated build,
+build deletes the environment afterwards, so you cannot inspect it once the build finishes.
+
+**Solution**: Build with ``-vv``. build prints the resolved version of every installed build dependency before it runs
+the backend:
+
+.. code-block:: console
+
+    $ python -m build --wheel -vv
+    ...
+    * Building wheel...
+      setuptools==80.9.0
+      wheel==0.45.1
+
+Copy the ``name==version`` line for the backend into your report. With ``--no-isolation`` build installs nothing, so
+read the version from the active interpreter instead (for example ``pip show setuptools``).
+
 *******************************
  Build hangs or appears frozen
 *******************************

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -31,6 +31,30 @@ By default build will build the package in an isolated environment, but this beh
 specified in your ``pyproject.toml``, runs the build, and then cleans up the environment. This ensures reproducible
 builds regardless of what packages are installed in your development environment.
 
+****************
+ Verbose Output
+****************
+
+Repeating ``-v`` raises the verbosity level. Each level adds to the previous one:
+
+- ``-v`` streams the output of the environment-creation and dependency-installation subprocesses.
+- ``-vv`` additionally prints the resolved version of every installed build dependency, one ``name==version`` per line,
+  and passes ``-v`` through to the installer.
+
+build reads the resolved versions from the isolated environment's installed metadata, so they reflect what was installed
+rather than the specifiers in ``pyproject.toml``:
+
+.. code-block:: console
+
+    $ python -m build --wheel -vv
+    ...
+    * Building wheel...
+      setuptools==80.9.0
+      wheel==0.45.1
+
+build reports this for isolated builds only; with ``--no-isolation`` build installs nothing, so inspect the active
+interpreter with your installer instead (for example ``pip list``).
+
 ************************
  Alternative CLI Script
 ************************

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -151,6 +151,23 @@ on your computer. It:
 3. Invoked the **build backend** to create the distribution files
 4. Cleaned up the temporary environment when done
 
+*****************************************
+ Seeing which backend versions were used
+*****************************************
+
+build deletes the isolated environment after each build, so it does not leave the installed versions behind. To see
+them, build with ``-vv``:
+
+.. code-block:: console
+
+    $ python -m build --wheel -vv
+    ...
+    * Building wheel...
+      hatchling==1.27.0
+
+build prints each installed build dependency as ``name==version``. Keep this handy when reporting a problem to a
+backend's issue tracker, which usually asks for the exact version you built with. See :doc:`../how-to/troubleshooting`.
+
 **********************************
  Building a wheel from your sdist
 **********************************

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -60,7 +60,7 @@ from build.env import DefaultIsolatedEnv
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
     from build._types import ConfigSettings, Distribution, StrPath, SubprocessRunner
 
@@ -111,25 +111,32 @@ def _make_logger() -> _ctx.Logger:
         max_terminal_width = 78
 
     fill = partial(textwrap.fill, subsequent_indent='  ', width=max_terminal_width)
+    return partial(_log, fill=fill)
 
-    def log(message: str, *, kind: tuple[str, ...] | None = None) -> None:
-        if _ctx.verbosity >= -1:
-            match kind:
-                case ('step', *_):
-                    (first, *rest) = message.splitlines()
-                    _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)
-                    for line in rest:
-                        print(fill(line, initial_indent='  '), file=sys.stderr)  # noqa: T201
-                case ('subprocess', 'cmd'):
-                    for line in message.splitlines():
-                        _cprint('{dim}{}{reset}', fill(line, initial_indent='> '), file=sys.stderr)
-                case ('subprocess', 'stdout' | 'stderr'):
-                    for line in message.splitlines():
-                        _cprint('{dim}{}{reset}', fill(line, initial_indent='< '), file=sys.stderr)
-                case _:
-                    print(fill(message, initial_indent='  '), file=sys.stderr)  # noqa: T201
 
-    return log
+def _log(message: str, *, fill: Callable[..., str], kind: tuple[str, ...] | None = None) -> None:
+    if _ctx.verbosity < -1:
+        return
+    match kind:
+        case ('step', *_):
+            first, _, rest = message.partition('\n')
+            _cprint('{bold}{}{reset}', fill(first, initial_indent='* '), file=sys.stderr)
+            _emit(rest, fill, indent='  ')
+        case ('subprocess', 'cmd'):
+            _emit(message, fill, indent='> ', style='{dim}{}{reset}')
+        case ('subprocess', 'stdout' | 'stderr'):
+            _emit(message, fill, indent='< ', style='{dim}{}{reset}')
+        case ('debug', *_) if _ctx.verbosity >= 2:
+            _emit(message, fill, indent='  ', style='{dim}{}{reset}')
+        case ('debug', *_):
+            pass
+        case _:
+            _emit(message, fill, indent='  ')
+
+
+def _emit(message: str, fill: Callable[..., str], *, indent: str, style: str = '{}') -> None:
+    for line in message.splitlines():
+        _cprint(style, fill(line, initial_indent=indent), file=sys.stderr)
 
 
 def _setup_cli(*, verbosity: int) -> None:
@@ -190,7 +197,10 @@ def _bootstrap_build_env(
             # first install the build dependencies
             install(builder.build_system_requires, _fresh=True)
             # then get the extra required dependencies from the backend (which was installed in the call above :P)
-            install(builder.get_requires_for_build(distribution, config_settings))
+            extra_requires = builder.get_requires_for_build(distribution, config_settings)
+            install(extra_requires)
+
+            _log_dependency_versions(env, builder.build_system_requires | extra_requires)
 
             yield builder
 
@@ -208,6 +218,14 @@ def _bootstrap_build_env(
                 _error(f'Missing dependencies:{dependencies}')
 
         yield builder
+
+
+def _log_dependency_versions(env: DefaultIsolatedEnv, requirements: set[str]) -> None:
+    if versions := env.installed_versions(requirements):
+        _ctx.log(
+            '\n'.join(f'{name}=={version}' for name, version in sorted(versions.items())),
+            kind=('debug',),
+        )
 
 
 def _build(

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -33,7 +33,11 @@ import tempfile
 import typing
 import warnings
 
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
 from . import _ctx
+from ._compat.importlib import metadata as importlib_metadata
 from ._ctx import run_subprocess
 from ._exceptions import FailedProcessError
 from ._util import check_dependency
@@ -43,8 +47,6 @@ TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping
-
-    from ._compat.importlib import metadata as importlib_metadata
 
     if sys.version_info < (3, 11):
         from typing_extensions import Self
@@ -161,6 +163,24 @@ class DefaultIsolatedEnv(IsolatedEnv):
             'PYTHONPATH': '',
         }
 
+    def installed_versions(self, requirements: Collection[str]) -> dict[str, str]:
+        """
+        Map the canonical name of each requirement to the version installed in the environment.
+
+        Requirements that resolved to nothing installed are omitted. Reads the distribution metadata
+        directly from the environment's ``purelib`` so no subprocess is spawned in the isolated environment.
+
+        :param requirements: PEP 508 requirement specifications to look up; non-PEP 508 entries (such as local
+            paths or URLs accepted by :meth:`install`) are skipped since their installed name cannot be derived
+        """
+        wanted = {name for requirement in requirements if (name := _canonical_requirement_name(requirement)) is not None}
+        distributions = importlib_metadata.distributions(path=[self._env_backend.purelib])
+        return {
+            name: distribution.version
+            for distribution in distributions
+            if (name := canonicalize_name(distribution.name)) in wanted
+        }
+
     def install(
         self,
         requirements: Collection[str],
@@ -186,9 +206,17 @@ class DefaultIsolatedEnv(IsolatedEnv):
         self._env_backend.install_dependencies(requirements, constraints, _fresh=_fresh)
 
 
+def _canonical_requirement_name(requirement: str) -> str | None:
+    try:
+        return canonicalize_name(Requirement(requirement).name)
+    except InvalidRequirement:
+        return None
+
+
 class _EnvBackend(typing.Protocol):  # pragma: no cover
     python_executable: str
     scripts_dir: str
+    purelib: str
 
     def create(self, path: str) -> None: ...
 
@@ -299,6 +327,7 @@ class _PipBackend(_EnvBackend):
             # The creator attributes are `pathlib.Path`s.
             self.python_executable = str(result.creator.exe)
             self.scripts_dir = str(result.creator.script_dir)
+            self.purelib = str(result.creator.purelib)
 
         else:
             import venv
@@ -312,6 +341,7 @@ class _PipBackend(_EnvBackend):
                 raise FailedProcessError(exc, 'Failed to create venv. Maybe try installing virtualenv.') from None
 
             self.python_executable, self.scripts_dir, purelib = _find_executable_and_scripts(path)
+            self.purelib = purelib
 
             if with_pip:
                 minimum_pip_version_str = self._get_minimum_pip_version_str()
@@ -403,7 +433,7 @@ class _UvBackend(_EnvBackend):
             self._uv_bin = uv_bin
 
         venv.EnvBuilder(symlinks=_fs_supports_symlink(), with_pip=False).create(self._env_path)
-        self.python_executable, self.scripts_dir, _ = _find_executable_and_scripts(self._env_path)
+        self.python_executable, self.scripts_dir, self.purelib = _find_executable_and_scripts(self._env_path)
 
     def install_dependencies(  # pragma: no cover -- uv tests are skipped on PyPy, covered on CPython
         self,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -37,6 +37,24 @@ def test_make_extra_environ_overrides_pythonpath() -> None:
         assert env._env_backend.scripts_dir in extra['PATH']
 
 
+def test_installed_versions(mocker: pytest_mock.MockerFixture) -> None:
+    env = build.env.DefaultIsolatedEnv()
+    env._env_backend = SimpleNamespace(purelib='/purelib')
+    distributions = mocker.patch(
+        'build._compat.importlib.metadata.distributions',
+        return_value=[
+            SimpleNamespace(name='Setuptools', version='80.9.0'),
+            SimpleNamespace(name='wheel', version='0.45.1'),
+            SimpleNamespace(name='pip', version='25.0'),
+        ],
+    )
+
+    versions = env.installed_versions(['setuptools >= 40.8.0', 'Wheel', '/local/path/pkg.whl'])
+
+    assert versions == {'setuptools': '80.9.0', 'wheel': '0.45.1'}
+    distributions.assert_called_once_with(path=['/purelib'])
+
+
 @pytest.mark.skipif(MISSING_UV, reason='uv executable not found')
 def test_uv_install_strips_pythonpath(
     mocker: pytest_mock.MockerFixture,
@@ -414,7 +432,9 @@ def test_virtualenv_no_wheel_flag(
 
     mocker.patch('build._compat.importlib.metadata.version', return_value=version)
     cli_run = mocker.patch('virtualenv.cli_run')
-    cli_run.return_value = SimpleNamespace(creator=SimpleNamespace(exe=Path('/fake/python'), script_dir=Path('/fake/scripts')))
+    cli_run.return_value = SimpleNamespace(
+        creator=SimpleNamespace(exe=Path('/fake/python'), script_dir=Path('/fake/scripts'), purelib=Path('/fake/purelib'))
+    )
 
     backend = build.env._PipBackend()
     backend.create('/some/path')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,6 +22,8 @@ import pytest_mock
 
 import build
 import build.__main__
+import build._ctx
+import build.env
 
 
 pytestmark = pytest.mark.contextvars
@@ -304,7 +306,7 @@ def test_build_isolated(mocker: pytest_mock.MockerFixture, package_test_flit: st
     required_cmd = mocker.patch(
         'build.ProjectBuilder.get_requires_for_build',
         side_effect=[
-            ['dep1', 'dep2'],
+            {'dep1', 'dep2'},
         ],
     )
     mocker.patch('build.__main__._error')
@@ -315,7 +317,7 @@ def test_build_isolated(mocker: pytest_mock.MockerFixture, package_test_flit: st
     install.assert_any_call({'flit_core >=2,<4'}, _fresh=True)
 
     required_cmd.assert_called_with('sdist', None)
-    install.assert_any_call(['dep1', 'dep2'])
+    install.assert_any_call({'dep1', 'dep2'})
 
     build_cmd.assert_called_with('sdist', '.', None)
 
@@ -628,6 +630,17 @@ def test_logging_output(
     assert set(stderr.splitlines()) <= set(output)
 
 
+@pytest.mark.network
+@pytest.mark.isolated
+@pytest.mark.flaky(reruns=5)
+def test_logging_output_double_verbose_backend_versions(
+    package_test_setuptools: str, tmp_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    build.__main__.main([package_test_setuptools, '-o', tmp_dir, '--wheel', '-vv'])
+    _, stderr = capsys.readouterr()
+    assert any(re.fullmatch(r' {2}setuptools==\d[\w.]*', line) for line in stderr.splitlines())
+
+
 @pytest.mark.pypy3323bug
 @pytest.mark.parametrize(
     ('color', 'stderr_error', 'stderr_body'),
@@ -838,6 +851,68 @@ def test_log_unknown_kind(mocker: pytest_mock.MockerFixture) -> None:
     mocker.patch('build.__main__._cprint')
     log = build.__main__._make_logger()
     log('message', kind=('unknown',))
+
+
+@pytest.mark.parametrize(
+    ('verbosity', 'expected'),
+    [
+        pytest.param(2, ['  setuptools==80.9.0'], id='double-verbose-shows-debug'),
+        pytest.param(1, [], id='single-verbose-hides-debug'),
+    ],
+)
+def test_log_debug_kind(verbosity: int, expected: list[str], capsys: pytest.CaptureFixture[str]) -> None:
+    build._ctx.VERBOSITY.set(verbosity)
+    build.__main__._styles.set(build.__main__._NO_COLORS)
+
+    build.__main__._make_logger()('setuptools==80.9.0', kind=('debug',))
+
+    assert capsys.readouterr().err.splitlines() == expected
+
+
+def test_log_dependency_versions(mocker: pytest_mock.MockerFixture) -> None:
+    env = mocker.create_autospec(build.env.DefaultIsolatedEnv, instance=True)
+    env.installed_versions.return_value = {'wheel': '0.45.1', 'setuptools': '80.9.0'}
+    log = mocker.patch('build.__main__._ctx.log')
+
+    build.__main__._log_dependency_versions(env, {'setuptools', 'wheel'})
+
+    log.assert_called_once_with('setuptools==80.9.0\nwheel==0.45.1', kind=('debug',))
+
+
+def test_log_dependency_versions_none(mocker: pytest_mock.MockerFixture) -> None:
+    env = mocker.create_autospec(build.env.DefaultIsolatedEnv, instance=True)
+    env.installed_versions.return_value = {}
+    log = mocker.patch('build.__main__._ctx.log')
+
+    build.__main__._log_dependency_versions(env, set())
+
+    log.assert_not_called()
+
+
+def test_bootstrap_build_env_logs_versions(mocker: pytest_mock.MockerFixture) -> None:
+    env = mocker.create_autospec(build.env.DefaultIsolatedEnv, instance=True)
+    env.__enter__.return_value = env
+    mocker.patch('build.__main__.DefaultIsolatedEnv', return_value=env)
+    builder = mocker.create_autospec(build.ProjectBuilder, instance=True)
+    builder.build_system_requires = {'setuptools'}
+    builder.get_requires_for_build.return_value = {'wheel'}
+    mocker.patch('build.ProjectBuilder.from_isolated_env', return_value=builder)
+    log_versions = mocker.patch('build.__main__._log_dependency_versions')
+
+    with build.__main__._bootstrap_build_env(
+        isolation=True,
+        srcdir='src',
+        distribution='wheel',
+        config_settings=None,
+        skip_dependency_check=False,
+        dependency_constraints_txt=None,
+        installer='pip',
+    ) as result:
+        assert result is builder
+
+    env.install.assert_any_call({'setuptools'}, _fresh=True)
+    env.install.assert_any_call({'wheel'})
+    log_versions.assert_called_once_with(env, {'setuptools', 'wheel'})
 
 
 def test_build_no_isolation_skip_dependency_check(mocker: pytest_mock.MockerFixture, package_test_flit: str) -> None:


### PR DESCRIPTION
When a build breaks, the next move is usually to file a report on the backend's issue tracker, and those trackers ask for the exact backend version you ran. build never showed it. The console lists only the requirement specifiers from `pyproject.toml` (`setuptools >= 40.8.0`), and on an isolated build the versions that were actually installed disappear with the temporary environment the moment the build ends. People work around this today by rerunning with `-v` and fishing the installer's `Successfully installed ...` line out of the pip output, by switching to `--no-isolation` to inspect their own environment, or by guessing. This addresses pypa/build#959.

Running with `-vv` now lists the resolved version of every build dependency as `name==version`, right where you are already looking when something goes wrong. 📦 Copy the backend's line straight into your bug report.

The versions reflect what the build actually used, including whatever the specifiers resolved to. Default and `-v` output stay the same, so only people who opt into `-vv` see the extra lines. With `--no-isolation` build installs nothing, so the versions come from your own interpreter instead.